### PR TITLE
Update summary.R

### DIFF
--- a/summary.R
+++ b/summary.R
@@ -189,7 +189,7 @@ if(!is.null(opt$metadata)){
     opt$metadata, stringsAsFactors = FALSE, row.names = rnname
   )
   extra_meta_donor[extra_meta_donor == ""] <- NA
-  extra_meta_donor_e <- extra_meta_donor[meta_donor$donor, ]
+  extra_meta_donor_e <- data.frame(extra_meta_donor[meta_donor$donor, ])
   rownames(extra_meta_donor_e) <- rownames(meta_donor)
   sapply(extra_meta_donor_e, table, useNA = 'always')
   meta_donor <- joindf(meta_donor, extra_meta_donor_e)

--- a/summary.R
+++ b/summary.R
@@ -189,7 +189,7 @@ if(!is.null(opt$metadata)){
     opt$metadata, stringsAsFactors = FALSE, row.names = rnname
   )
   extra_meta_donor[extra_meta_donor == ""] <- NA
-  extra_meta_donor_e <- data.frame(extra_meta_donor[meta_donor$donor, ])
+  extra_meta_donor_e <- extra_meta_donor[meta_donor$donor, , drop = FALSE]
   rownames(extra_meta_donor_e) <- rownames(meta_donor)
   sapply(extra_meta_donor_e, table, useNA = 'always')
   meta_donor <- joindf(meta_donor, extra_meta_donor_e)


### PR DESCRIPTION
Hi Ciro!

When we run this pipeline with just one library got this error:
Error in `rownames<-`(`*tmp*`, value = c("AAACCCAAGACATAAC-1", "AAACCCAAGCGTTACT-1",  : 
  attempt to set 'rownames' on an object with no dimensions

As the library is just one, the command "extra_meta_donor_e <- extra_meta_donor[meta_donor$donor, ]" returns just one vector, and in the line below  "rownames" can't assign the names because there aren't rows. Make the object a dataframe solves this problem and we think doesn't affect if there are more libraries.